### PR TITLE
use libi2c / add install target

### DIFF
--- a/24cXX.h
+++ b/24cXX.h
@@ -16,6 +16,7 @@
 #ifndef _24CXX_H_
 #define _24CXX_H_
 #include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 
 #define EEPROM_TYPE_UNKNOWN	0
 #define EEPROM_TYPE_8BIT_ADDR	1

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ clean:
 	rm -f eeprog eeprog.o 24cXX.o
 
 eeprog: eeprog.o 24cXX.o
+	$(CC) -o $@ $? -li2c
 
 eeprog-static: eeprog.o 24cXX.o
-	$(CC) -static -o $@ $?
+	$(CC) -static -o $@ $? -li2c

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,9 @@ eeprog: eeprog.o 24cXX.o
 
 eeprog-static: eeprog.o 24cXX.o
 	$(CC) -static -o $@ $? -li2c
+
+.PHONY: install install-static
+install: eeprog
+	install eeprog /usr/local/bin
+install-static: eeprog-static
+	install eeprog-static /usr/local/bin/eeprog

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-CFLAGS=-g -I. -Wall -O2   
+CFLAGS=-g -I. -Wall -O2
 
-all: eeprog 
+all: eeprog
 
-clean: 
+clean:
 	rm -f eeprog eeprog.o 24cXX.o
 
 eeprog: eeprog.o 24cXX.o


### PR DESCRIPTION
i2c/smbus.h also used to provide these functions but now they have
been moved to a library, libi2c.

add an install target to the makefile