### PR TITLE
fix linking with i2c libraries

### DIFF
--- a/24cXX.h
+++ b/24cXX.h
@@ -16,6 +16,8 @@
 #ifndef _24CXX_H_
 #define _24CXX_H_
 #include <linux/i2c-dev.h>
+#include <linux/i2c.h>
+#include <i2c/smbus.h>
 
 #define EEPROM_TYPE_UNKNOWN	0
 #define EEPROM_TYPE_8BIT_ADDR	1

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ clean:
 	rm -f eeprog eeprog.o 24cXX.o
 
 eeprog: eeprog.o 24cXX.o
+	$(CC) $(CFLAGS) -o $@ $^ -li2c
 
 eeprog-static: eeprog.o 24cXX.o
 	$(CC) -static -o $@ $?


### PR DESCRIPTION
The location of the definition of some i2c stuff seemed changed.
Now we need to install the libi2c for some of the functions.

to install dependency:
`sudo apt install libi2c-dev`